### PR TITLE
Webfont formatting improvements

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -13,7 +13,7 @@ function get_table_open_markup() {
 		<table class="paragraphtable" style="width: 100%;">
 			<tbody>
 				<tr>
-					<td class="montserratlight" style="width: 100%; font-family: Helvetica, Arial, sans-serif; padding: 0px 0px 16px 0px; margin: 0;">
+					<td style="width: 100%; font-family: 'UCF-Sans-Serif-Alt', Helvetica, Arial, sans-serif; padding: 0px 0px 16px 0px; margin: 0;">
 	<?php
 	return ob_get_clean();
 }
@@ -50,7 +50,7 @@ function get_h2_open_markup() {
 		<table class="paragraphtable" style="width: 100%;">
 			<tbody>
 				<tr>
-					<td class="montserratbold" style="width: 100%; font-family: Helvetica, Arial, sans-serif; font-size: 18px; font-weight: bold; padding: 0px 0px 16px 0px; margin: 0;">
+					<td style="width: 100%; font-family: 'UCF-Sans-Serif-Alt', Helvetica, Arial, sans-serif; font-size: 18px; font-weight: bold; padding: 0px 0px 16px 0px; margin: 0;">
 	<?php
 	return ob_get_clean();
 }

--- a/templates/leadership/css.php
+++ b/templates/leadership/css.php
@@ -3,24 +3,24 @@
     font-family: "UCF-Sans-Serif-Alt";
     font-style: normal;
     font-weight: 400;
-    src: url('http://cdn.ucf.edu/athena-framework/latest/fonts/ucf-sans-serif-alt/ucfsansserifalt-medium-webfont.woff2') format("woff2"),
-	  url('http://cdn.ucf.edu/athena-framework/latest/fonts/ucf-sans-serif-alt/ucfsansserifalt-medium-webfont.woff') format("woff");
+    src: url('https://s3.amazonaws.com/web.ucf.edu/email/common-assets/fonts/ucfsansserifalt-medium-webfont.woff2') format("woff2"),
+	  url('https://s3.amazonaws.com/web.ucf.edu/email/common-assets/fonts/ucfsansserifalt-medium-webfont.woff') format("woff");
 	mso-font-alt: 'Arial';
   }
   @font-face {
     font-family: "UCF-Sans-Serif-Alt";
     font-style: normal;
     font-weight: 500;
-    src: url('http://cdn.ucf.edu/athena-framework/latest/fonts/ucf-sans-serif-alt/ucfsansserifalt-semibold-webfont.woff2') format("woff2"),
-	  url('http://cdn.ucf.edu/athena-framework/latest/fonts/ucf-sans-serif-alt/ucfsansserifalt-semibold-webfont.woff') format("woff");
+    src: url('https://s3.amazonaws.com/web.ucf.edu/email/common-assets/fonts/ucfsansserifalt-semibold-webfont.woff2') format("woff2"),
+	  url('https://s3.amazonaws.com/web.ucf.edu/email/common-assets/fonts/ucfsansserifalt-semibold-webfont.woff') format("woff");
 	mso-font-alt: 'Arial';
   }
   @font-face {
     font-family: "UCF-Sans-Serif-Alt";
     font-style: normal;
     font-weight: 700;
-    src: url('http://cdn.ucf.edu/athena-framework/latest/fonts/ucf-sans-serif-alt/ucfsansserifalt-bold-webfont.woff2') format("woff2"),
-	  url('http://cdn.ucf.edu/athena-framework/latest/fonts/ucf-sans-serif-alt/ucfsansserifalt-bold-webfont.woff') format("woff");
+    src: url('https://s3.amazonaws.com/web.ucf.edu/email/common-assets/fonts/ucfsansserifalt-bold-webfont.woff2') format("woff2"),
+	  url('https://s3.amazonaws.com/web.ucf.edu/email/common-assets/fonts/ucfsansserifalt-bold-webfont.woff') format("woff");
 	mso-font-alt: 'Arial';
   }
 

--- a/templates/leadership/css.php
+++ b/templates/leadership/css.php
@@ -1,42 +1,29 @@
 <style type="text/css">
   @font-face {
-    font-family: 'montserratbold';
-    src: url('https://s3.amazonaws.com/web.ucf.edu/email/common-assets/fonts/montserrat-bold-webfont.eot');
-    src: url('https://s3.amazonaws.com/web.ucf.edu/email/common-assets/fonts/montserrat-bold-webfont.eot?#iefix') format('embedded-opentype'),
-      url('https://s3.amazonaws.com/web.ucf.edu/email/common-assets/fonts/montserrat-bold-webfont.woff2') format('woff2'),
-      url('https://s3.amazonaws.com/web.ucf.edu/email/common-assets/fonts/montserrat-bold-webfont.woff') format('woff'),
-      url('https://s3.amazonaws.com/web.ucf.edu/email/common-assets/fonts/montserrat-bold-webfont.ttf') format('truetype'),
-      url('https://s3.amazonaws.com/web.ucf.edu/email/common-assets/fonts/montserrat-bold-webfont.svg#montserratbold') format('svg');
-    font-weight: normal;
+    font-family: "UCF-Sans-Serif-Alt";
     font-style: normal;
-    letter-spacing: 1px;
+    font-weight: 400;
+    src: url('http://cdn.ucf.edu/athena-framework/latest/fonts/ucf-sans-serif-alt/ucfsansserifalt-medium-webfont.woff2') format("woff2"),
+	  url('http://cdn.ucf.edu/athena-framework/latest/fonts/ucf-sans-serif-alt/ucfsansserifalt-medium-webfont.woff') format("woff");
+	mso-font-alt: 'Arial';
+  }
+  @font-face {
+    font-family: "UCF-Sans-Serif-Alt";
+    font-style: normal;
+    font-weight: 500;
+    src: url('http://cdn.ucf.edu/athena-framework/latest/fonts/ucf-sans-serif-alt/ucfsansserifalt-semibold-webfont.woff2') format("woff2"),
+	  url('http://cdn.ucf.edu/athena-framework/latest/fonts/ucf-sans-serif-alt/ucfsansserifalt-semibold-webfont.woff') format("woff");
+	mso-font-alt: 'Arial';
+  }
+  @font-face {
+    font-family: "UCF-Sans-Serif-Alt";
+    font-style: normal;
+    font-weight: 700;
+    src: url('http://cdn.ucf.edu/athena-framework/latest/fonts/ucf-sans-serif-alt/ucfsansserifalt-bold-webfont.woff2') format("woff2"),
+	  url('http://cdn.ucf.edu/athena-framework/latest/fonts/ucf-sans-serif-alt/ucfsansserifalt-bold-webfont.woff') format("woff");
+	mso-font-alt: 'Arial';
   }
 
-  @font-face {
-    font-family: 'montserratlight';
-    src: url('https://s3.amazonaws.com/web.ucf.edu/email/common-assets/fonts/montserrat-light-webfont.eot');
-    src: url('https://s3.amazonaws.com/web.ucf.edu/email/common-assets/fonts/montserrat-light-webfont.eot?#iefix') format('embedded-opentype'),
-      url('https://s3.amazonaws.com/web.ucf.edu/email/common-assets/fonts/montserrat-light-webfont.woff2') format('woff2'),
-      url('https://s3.amazonaws.com/web.ucf.edu/email/common-assets/fonts/montserrat-light-webfont.woff') format('woff'),
-      url('https://s3.amazonaws.com/web.ucf.edu/email/common-assets/fonts/montserrat-light-webfont.ttf') format('truetype'),
-      url('https://s3.amazonaws.com/web.ucf.edu/email/common-assets/fonts/montserrat-light-webfont.svg#montserratlight') format('svg');
-    font-weight: normal;
-    font-style: normal;
-    letter-spacing: 1px;
-  }
-
-  @font-face {
-    font-family: 'montserratsemi_bold';
-    src: url('https://s3.amazonaws.com/web.ucf.edu/email/common-assets/fonts/montserrat-semibold-webfont.eot');
-    src: url('https://s3.amazonaws.com/web.ucf.edu/email/common-assets/fonts/montserrat-semibold-webfont.eot?#iefix') format('embedded-opentype'),
-      url('https://s3.amazonaws.com/web.ucf.edu/email/common-assets/fonts/montserrat-semibold-webfont.woff2') format('woff2'),
-      url('https://s3.amazonaws.com/web.ucf.edu/email/common-assets/fonts/montserrat-semibold-webfont.woff') format('woff'),
-      url('https://s3.amazonaws.com/web.ucf.edu/email/common-assets/fonts/montserrat-semibold-webfont.ttf') format('truetype'),
-      url('https://s3.amazonaws.com/web.ucf.edu/email/common-assets/fonts/montserrat-semibold-webfont.svg#montserratsemi_bold') format('svg');
-    font-weight: normal;
-    font-style: normal;
-    letter-spacing: 1px;
-  }
 
   /* CSS Resets */
 
@@ -59,13 +46,14 @@
     line-height: 100%;
   }
 
-  body {
-    -webkit-text-size-adjust: none;
-    -ms-text-size-adjust: none;
+  * {
+    zoom: 1;
   }
 
   body {
-    margin: 0;
+    -webkit-text-size-adjust: none; /* ios likes to enforce a minimum font size of 13px; kill it with this */
+    -ms-text-size-adjust: none;
+	margin: 0;
     padding: 0;
   }
 
@@ -77,64 +65,10 @@
     border-collapse: collapse;
   }
 
-  * {
-    zoom: 1;
-  }
-
   a {
     color: #006699;
   }
 
-  div,
-  p,
-  a,
-  li,
-  td {
-    -webkit-text-size-adjust: none;
-  }
-
-  /* ios likes to enforce a minimum font size of 13px; kill it with this */
-
-  /**
-      * Outlook 2007-2013 hates inline webfont declarations and won't use fallback fonts,
-      * so use class-based overrides instead
-      **/
-
-  *[class="montserratlight"] {
-    font-family: 'montserratlight', Helvetica, Arial, sans-serif !important;
-  }
-
-  *[class="montserratsemibold"] {
-    font-family: 'montserratsemi_bold', Helvetica, Arial, sans-serif !important;
-  }
-
-  *[class="montserratbold"] {
-    font-family: 'montserratbold', Helvetica, Arial, sans-serif !important;
-    font-weight: normal !important;
-  }
-
-  td[class="givebtn"] {
-    font-family: 'montserratsemi_bold', Helvetica, Arial, sans-serif !important;
-  }
-
-  td[class="givedesc"] {
-    font-family: 'montserratsemi_bold', Helvetica, Arial, sans-serif !important;
-  }
-
-  /*
-      * General styles for the editor to maintain consistency btwn it and
-      * generated email markup
-      */
-
-  p {
-    display: block;
-    width: 100%;
-    padding-bottom: 20px;
-  }
-
-  p span {
-    line-height: inherit;
-  }
 
   @media all and (max-width: 640px) {
 
@@ -249,15 +183,6 @@
       padding-left: 0 !important;
       padding-right: 0 !important;
       padding-bottom: 20px !important;
-    }
-
-    td[class="givebtn"] {
-      font-size: 16px !important;
-      padding: 10px !important;
-    }
-
-    td[class="givedesc"] {
-      font-size: 16px !important;
     }
   }
 

--- a/templates/leadership/footer.php
+++ b/templates/leadership/footer.php
@@ -6,8 +6,7 @@
                         <table style="width: 100%;" align="center">
                             <tbody>
                                 <tr>
-                                    <td style="padding-top: 15px; padding-bottom: 20px; padding-left: 0; padding-right: 0; width:100%;"
-                                        align="center">
+                                    <td style="padding-top: 15px; padding-bottom: 20px; padding-left: 0; padding-right: 0; width:100%;" align="center">
                                         <hr style="border: none; border-top: 1px solid lightgrey;">
                                     </td>
                                 </tr>
@@ -20,26 +19,25 @@
                         <table style="font-family: Helvetica, Arial, sans-serif; font-size: 13px; line-height: 1.4em;" align="center">
                             <tbody>
                                 <tr>
-                                    <td class="montserratbold" style="text-align: center; padding-bottom: 2px; padding-left: 0; padding-right: 0; font-family: Helvetica, Arial, sans-serif; font-size: 13px; font-weight: bold; text-transform: uppercase; color: #000; letter-spacing: 1.25px;" align="center">
-                                        <a style="text-decoration: none; color: #000;" href="https://www.ucf.edu/">University of
-                                            Central Florida</a>
+                                    <td style="text-align: center; padding-bottom: 2px; padding-left: 0; padding-right: 0; font-family: 'UCF-Sans-Serif-Alt', Helvetica, Arial, sans-serif; font-size: 13px; font-weight: bold; text-transform: uppercase; color: #000; letter-spacing: 1.25px;" align="center">
+                                        <a style="text-decoration: none; color: #000;" href="https://www.ucf.edu/">University of Central Florida</a>
                                     </td>
                                 </tr>
 
                                 <tr>
-                                    <td class="montserratlight" style="text-align: center; padding-bottom: 2px; padding-left: 0; padding-right: 0; font-family: Helvetica, Arial, sans-serif; font-size: 13px; color: #000;" align="center">
+                                    <td style="text-align: center; padding-bottom: 2px; padding-left: 0; padding-right: 0; font-family: 'UCF-Sans-Serif-Alt', Helvetica, Arial, sans-serif; font-size: 13px; color: #000;" align="center">
                                         4000 Central Florida Blvd.
                                     </td>
                                 </tr>
 
                                 <tr>
-                                    <td class="montserratlight" style="text-align: center; padding-bottom: 20px; padding-left: 0; padding-right: 0; font-family: Helvetica, Arial, sans-serif; font-size: 13px; color: #000;" align="center">
+                                    <td style="text-align: center; padding-bottom: 20px; padding-left: 0; padding-right: 0; font-family: 'UCF-Sans-Serif-Alt', Helvetica, Arial, sans-serif; font-size: 13px; color: #000;" align="center">
                                         Orlando, FL 32816
                                     </td>
                                 </tr>
 
                                 <tr>
-                                    <td class="montserratlight" style="text-align: center; padding-bottom: 20px; padding-left: 0; padding-right: 0; font-family: Helvetica, Arial, sans-serif; font-size: 13px; color: #000;" align="center">
+                                    <td style="text-align: center; padding-bottom: 20px; padding-left: 0; padding-right: 0; font-family: 'UCF-Sans-Serif-Alt', Helvetica, Arial, sans-serif; font-size: 13px; color: #000;" align="center">
                                         !@!UNSUBSCRIBE!@! from this email.
                                     </td>
                                 </tr>

--- a/templates/leadership/header.php
+++ b/templates/leadership/header.php
@@ -5,12 +5,7 @@
   <meta http-equiv="Content-Type" content="text/html;charset=UTF-8">
   <meta name="format-detection" content="telephone=no">
   <meta name="viewport" content="initial-scale=1.0">
-
-  <!-- So that mobile webkit will display zoomed in -->
-  <link rel="stylesheet" type="text/css" href="https://s3.amazonaws.com/web.ucf.edu/email/common-assets/stylesheet.css">
-  <title>
-    <?php wp_strip_all_tags( the_title() ); ?>
-  </title>
+  <title><?php wp_strip_all_tags( the_title() ); ?></title>
 
   <?php include_once( 'css.php' ); ?>
 </head>

--- a/templates/leadership/leadership-template.php
+++ b/templates/leadership/leadership-template.php
@@ -15,7 +15,7 @@
 <table class="tcollapse100" width="564" border="0" align="center">
   <tbody>
   <tr>
-    <td class="montserratbold" style="padding-left: 0; padding-right: 0; font-family: Helvetica, Arial, sans-serif; font-size: 35px; font-weight: bold; padding-top: 20px; padding-bottom: 30px; line-height: 1.1; color: #000; text-align: left;" align="left">
+    <td style="padding-left: 0; padding-right: 0; font-family: 'UCF-Sans-Serif-Alt', Helvetica, Arial, sans-serif; font-size: 35px; font-weight: bold; padding-top: 20px; padding-bottom: 30px; line-height: 1.1; color: #000; text-align: left;" align="left">
       <?php the_title(); ?>
     </td>
   </tr>
@@ -24,7 +24,7 @@
     <table class="tcollapse100" align="center" style="width: 100%;">
       <tbody>
       <tr>
-        <td class="ccollapse100" style="font-family: Helvetica, Arial, sans-serif; font-size: 15px; line-height: 1.5;">
+        <td class="ccollapse100" style="font-family: 'UCF-Sans-Serif-Alt', Helvetica, Arial, sans-serif; font-size: 15px; line-height: 1.5;">
           <?php the_content(); ?>
           <?php echo get_email_signature(); ?>
         </td>


### PR DESCRIPTION
<!---
Thank you for contributing to UCF-Email-Editor-Plugin.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/UCF-Email-Editor-Plugin/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
<!--- Describe your changes in detail -->
Updated how custom webfonts are included in email markup to use a single, combined font definition, instead of definitions per each font weight.  This, combined with the `mso-font-alt` rule in each `@font-face` declaration (for Outlook compatibility), allows us to use our "sans serif alt" font like we would any other font, and eliminates the need for font-weight-specific CSS classes.  With this update, font weights should render consistently whether or not webfonts get loaded in.

I also removed the `common-assets/stylesheet.css` stylesheet inclusion in the header template, since it's redundant and not needed.

Some other small cruft has also been cleaned up (e.g. combining selectors in our styles, removing stuff that's not necessary.)

**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes inconsistencies between email clients' rendering of font weights, and whether or not they load webfonts.

Also coincidentally resolves #7 by fixing rendering of `<strong>` tags without needing to find+replace them in a filter. 

**How Has This Been Tested?**
<!--- Please describe how you tested your changes. -->
Reviewed in Dev + Litmus.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
