### PR TITLE
Added ability to hide email title in markup

### DIFF
--- a/dev/acf-export.json
+++ b/dev/acf-export.json
@@ -4,11 +4,11 @@
         "title": "Email Field Group",
         "fields": [
             {
-                "key": "field_5e7a6a6383ad0",
-                "label": "Email Signature",
-                "name": "email_signature",
+                "key": "field_5e8247fa55751",
+                "label": "Email Header",
+                "name": "email_header",
                 "type": "post_object",
-                "instructions": "Select the signature to use for this email.",
+                "instructions": "Select the header to use for this email.",
                 "required": 0,
                 "conditional_logic": 0,
                 "wrapper": {
@@ -26,11 +26,30 @@
                 "ui": 1
             },
             {
-                "key": "field_5e8247fa55751",
-                "label": "Email Header",
-                "name": "email_header",
+                "key": "field_5ed121a3c7d14",
+                "label": "Hide Email Title",
+                "name": "email_hide_title",
+                "type": "true_false",
+                "instructions": "If checked, the email title will not be displayed at the top of the email template.",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "message": "Hide title",
+                "default_value": 0,
+                "ui": 1,
+                "ui_on_text": "",
+                "ui_off_text": ""
+            },
+            {
+                "key": "field_5e7a6a6383ad0",
+                "label": "Email Signature",
+                "name": "email_signature",
                 "type": "post_object",
-                "instructions": "Select the header to use for this email.",
+                "instructions": "Select the signature to use for this email.",
                 "required": 0,
                 "conditional_logic": 0,
                 "wrapper": {

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -192,6 +192,25 @@ function get_email_header() {
 
 
 /**
+ * Get the selected email title
+ *
+ * @since 1.1.6
+ * @author Jo Dickson
+ * @return string email title
+ */
+function get_email_title() {
+	$title = '';
+	$hide_title = get_field( 'email_hide_title' );
+
+	if ( $hide_title !== true ) {
+		$title = get_the_title();
+	}
+
+	return $title;
+}
+
+
+/**
 * Get the selected email signature
 *
 * @since 1.0.0

--- a/templates/blank/blank-template.php
+++ b/templates/blank/blank-template.php
@@ -14,11 +14,13 @@
 
 <table class="tcollapse100" width="564" border="0" align="center">
   <tbody>
+  <?php if ( $title = get_email_title() ): ?>
   <tr>
     <td style="padding-left: 0; padding-right: 0; font-family: 'UCF-Sans-Serif-Alt', Helvetica, Arial, sans-serif; font-size: 35px; font-weight: bold; padding-top: 20px; padding-bottom: 30px; line-height: 1.1; color: #000; text-align: left;" align="left">
-      <?php the_title(); ?>
+      <?php echo $title; ?>
     </td>
   </tr>
+  <?php endif; ?>
   <tr>
     <td class="ccollapse100" style="width: 100%;">
     <table class="tcollapse100" align="center" style="width: 100%;">


### PR DESCRIPTION
<!---
Thank you for contributing to UCF-Email-Editor-Plugin.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/UCF-Email-Editor-Plugin/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
<!--- Describe your changes in detail -->
See title (or don't 🥁 )

**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We occasionally send emails with custom headers that don't need the title of the email displayed below them.

**How Has This Been Tested?**
<!--- Please describe how you tested your changes. -->
Reviewed in Dev.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
