### PR TITLE
Instant send

### DIFF
--- a/admin/email-admin.php
+++ b/admin/email-admin.php
@@ -4,12 +4,49 @@
  */
 
 
-function instant_sent_button( $post ) {
+function instant_send_button( $post ) {
 ?>
 <div class="misc-pub-section instant-send">
-	<a style="margin-bottom: 12px;" class="preview button" href="/preview/" target="wp-preview-<?php echo $post->ID; ?>" id="instant-send">Send Preview</a>
+	<a style="margin-bottom: 12px;" class="preview button" href="#send-preview" id="instant-send">Send Preview</a>
 </div>
 <?php
 }
 
-add_action( 'post_submitbox_misc_actions', 'instant_sent_button', 10, 1 );
+add_action( 'post_submitbox_misc_actions', 'instant_send_button', 10, 1 );
+
+function insert_instant_send_js() {
+	global $post;
+
+	if ( $post->post_type !== 'ucf-email' ) return;
+
+?>
+	<script>
+		$post_id = <?php echo $post->ID; ?>;
+
+		var data = {
+			post_id: $post_id,
+			action: 'instant-send'
+		};
+
+		var onPostSuccess = function(response) {
+			var $markup = jQuery(
+				'<div class="updated notice notice-success is-dismissible">' +
+					'<p>Preview of email sent.</p>' +
+				'</div>'
+			);
+
+			$markup.insertAfter('.wp-header-end');
+		};
+
+		jQuery('#instant-send').on('click', function() {
+			jQuery.post(
+				ajaxurl,
+				data,
+				onPostSuccess
+			);
+		});
+	</script>
+<?php
+}
+
+add_action( 'admin_footer-post.php', 'insert_instant_send_js', 10, 1 );

--- a/admin/email-admin.php
+++ b/admin/email-admin.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Handles admin related functions
+ */
+
+
+function instant_sent_button( $post ) {
+?>
+<div class="misc-pub-section instant-send">
+	<a style="margin-bottom: 12px;" class="preview button" href="/preview/" target="wp-preview-<?php echo $post->ID; ?>" id="instant-send">Send Preview</a>
+</div>
+<?php
+}
+
+add_action( 'post_submitbox_misc_actions', 'instant_sent_button', 10, 1 );

--- a/includes/email-send-functions.php
+++ b/includes/email-send-functions.php
@@ -31,18 +31,27 @@ function send_instant_preview( $args ) {
 
 	$sender = "From: $from_friendly <$from_email>";
 
-	$headers[] = $sender;
+	$headers[] = 'MIME-Version: 1.0';
 	$headers[] = 'Content-Type: text/html; charset=UTF-8';
-
-	// DEBUG REMEMBER TO REMOVE!
-	$args['to'] = array( 'james.barnes@ucf.edu' );
+	$headers[] = $sender;
 
 	return wp_mail(
 		$args['to'],
-		$args['subject'],
-		$args['body'],
+		trim( $args['subject'] ),
+		trim( $args['body'] ),
 		$headers
 	);
+}
+
+/**
+ * Helper function for text/html issues
+ * @author Jim Barnes
+ * @since 1.2.0
+ * @param string $content_type
+ * @return string
+ */
+function gmucf_content_type( $content_type ) {
+	return 'text/html';
 }
 
 /**
@@ -54,21 +63,25 @@ function send_instant_preview( $args ) {
  * @return string
  */
 function generate_email_markup( $post_id ) {
+	global $wp_query;
+
+	$wp_the_query = $wp_query;
+
 	$args = array(
-		'id' => $post_id
+		'p'         => $post_id,
+		'post_type' => 'ucf-email'
 	);
 
 	$query = new WP_Query( $args );
 
+	$wp_query = $query;
+
 	ob_start();
 
-	while ( $query->have_posts() ) : $query->the_post();
+	include_once UCF_EMAIL_EDITOR__PLUGIN_DIR . 'templates/blank/blank-template.php';
 
-	include UCF_EMAIL_EDITOR__PLUGIN_DIR . 'templates/blank/blank-template.php';
-
-	endwhile;
-
-	wp_reset_postdata();
+	// Reset wp_query
+	$wp_query = $wp_the_query;
 
 	return ob_get_clean();
 }

--- a/includes/email-send-functions.php
+++ b/includes/email-send-functions.php
@@ -34,6 +34,9 @@ function send_instant_preview( $args ) {
 	$headers[] = $sender;
 	$headers[] = 'Content-Type: text/html; charset=UTF-8';
 
+	// DEBUG REMEMBER TO REMOVE!
+	$args['to'] = array( 'james.barnes@ucf.edu' );
+
 	return wp_mail(
 		$args['to'],
 		$args['subject'],
@@ -52,16 +55,16 @@ function send_instant_preview( $args ) {
  */
 function generate_email_markup( $post_id ) {
 	$args = array(
-		'post_id' => $post_id
+		'id' => $post_id
 	);
 
 	$query = new WP_Query( $args );
 
 	ob_start();
 
-	while ( have_posts() ) : the_post();
+	while ( $query->have_posts() ) : $query->the_post();
 
-	include 'templates/blank/blank-template.php';
+	include UCF_EMAIL_EDITOR__PLUGIN_DIR . 'templates/blank/blank-template.php';
 
 	endwhile;
 
@@ -95,4 +98,4 @@ function instant_send_ajax() {
 	wp_die();
 }
 
-add_action( 'wp_ajax_instant_send', 'instant_send_ajax', 10 );
+add_action( 'wp_ajax_instant-send', 'instant_send_ajax', 10 );

--- a/includes/email-send-functions.php
+++ b/includes/email-send-functions.php
@@ -87,20 +87,38 @@ function generate_email_markup( $post_id ) {
 }
 
 /**
- * The ajax handlers for the instant send.
+ * Sends an email instantly
  * @author Jim Barnes
- * @since 1.2.0
+ * @since 1.0.0
  */
-function instant_send_ajax() {
-	$post_id = intval( $_POST['post_id'] );
-
+function instant_send( $post_id ) {
 	$markup = generate_email_markup( $post_id );
+
+	/**
+	 * TODO: Need to create logic that handles
+	 * getting the to, from and subject from
+	 * the ACF fields that are being defined
+	 * in another branch.
+	 */
 
 	$args = array(
 		'body' => $markup
 	);
 
 	$send = send_instant_preview( $args );
+
+	return $send;
+}
+
+/**
+ * The ajax handler for the instant send.
+ * @author Jim Barnes
+ * @since 1.2.0
+ */
+function instant_send_ajax() {
+	$post_id = intval( $_POST['post_id'] );
+
+	$send = instant_send( $post_id );
 
 	$retval = array(
 		'success' => $send

--- a/includes/email-send-functions.php
+++ b/includes/email-send-functions.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * Provides the functions necessary for instantly
+ * sending email markup
+ */
+
+/**
+ * Properly formats incoming arguments
+ * to send an email from WordPress
+ * @author Jim Barnes
+ * @since 1.2.0
+ * @param array $args The argument array
+ * @return bool True if the email was sent.
+ */
+function send_instant_preview( $args ) {
+	$args = shortcode_atts(
+		array(
+			'to'            => array( 'webcom@ucf.edu' ),
+			'subject'       => '**PREVIEW** Test Email **PREVIEW**',
+			'from_friendly' => 'Good Morning UCF Admin',
+			'from'          => 'webcom@ucf.edu',
+			'body'          => 'Hello World',
+		),
+		$args
+	);
+
+	$headers = array();
+
+	$from_friendly = $args['from_friendly'];
+	$from_email    = $args['from'];
+
+	$sender = "From: $from_friendly <$from_email>";
+
+	$headers[] = $sender;
+	$headers[] = 'Content-Type: text/html; charset=UTF-8';
+
+	return wp_mail(
+		$args['to'],
+		$args['subject'],
+		$args['body'],
+		$headers
+	);
+}
+
+/**
+ * Generates markup for an email based
+ * on the email id
+ * @author Jim Barnes
+ * @since 1.2.0
+ * @param int $post_id
+ * @return string
+ */
+function generate_email_markup( $post_id ) {
+	$args = array(
+		'post_id' => $post_id
+	);
+
+	$query = new WP_Query( $args );
+
+	ob_start();
+
+	while ( have_posts() ) : the_post();
+
+	include 'templates/blank/blank-template.php';
+
+	endwhile;
+
+	wp_reset_postdata();
+
+	return ob_get_clean();
+}
+
+/**
+ * The ajax handlers for the instant send.
+ * @author Jim Barnes
+ * @since 1.2.0
+ */
+function instant_send_ajax() {
+	$post_id = intval( $_POST['post_id'] );
+
+	$markup = generate_email_markup( $post_id );
+
+	$args = array(
+		'body' => $markup
+	);
+
+	$send = send_instant_preview( $args );
+
+	$retval = array(
+		'success' => $send
+	);
+
+	echo json_encode( $retval );
+
+	wp_die();
+}
+
+add_action( 'wp_ajax_instant_send', 'instant_send_ajax', 10 );

--- a/ucf-email-editor-plugin.php
+++ b/ucf-email-editor-plugin.php
@@ -22,6 +22,8 @@ define( 'UCF_EMAIL_EDITOR__IMG_URL', UCF_EMAIL_EDITOR__STATIC_URL . '/img' );
 include_once 'includes/functions.php';
 include_once 'includes/ucf-email-editor-config.php';
 include_once 'includes/ucf-email-posttype.php';
+include_once 'includes/email-send-functions.php';
+include_once 'admin/email-admin.php';
 include_once 'templates/templates.php';
 
 if ( ! function_exists( 'ucf_email_editor_plugin_activation' ) ) {


### PR DESCRIPTION
<!---
Thank you for contributing to UCF-Email-Editor-Plugin.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/UCF-Email-Editor-Plugin/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
Adds the ability to instantly send a preview of an email. There is currently some logic missing that will handle who the email is sent to, setting the subject line, and to whom it's from. That will be added when the ACF fields that will store those are merged into the rc branch.

**Motivation and Context**
Allows us to send instant previews to stake holders without having to transfer the HTML over to s3 and do it from postmaster.

**How Has This Been Tested?**
Changes have been tested locally and are available in dev.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
