### PR TITLE
Pared-down WYSIWYG toolbar options for emails

### DIFF
--- a/includes/admin.php
+++ b/includes/admin.php
@@ -1,0 +1,116 @@
+<?php
+
+/**
+ * Defines buttons that should be present in the first row
+ * of WYSIWYG toolbars for email editing.
+ *
+ * @since 1.2.0
+ * @author Jo Dickson
+ * @return array
+ */
+function email_wysiwyg_toolbar_r1() {
+	return array(
+		'formatselect',
+		'bold',
+		'italic',
+		'bullist',
+		'numlist',
+		'link',
+		'unlink',
+		'pastetext',
+		'removeformat',
+		'charmap',
+		'undo',
+		'redo'
+	);
+}
+
+
+/**
+ * Defines buttons that should be present in the second row
+ * of WYSIWYG toolbars for email editing.
+ *
+ * @since 1.2.0
+ * @author Jo Dickson
+ * @return array
+ */
+function email_wysiwyg_toolbar_r2() {
+	return array();
+}
+
+
+/**
+ * Adds a custom ACF WYSIWYG toolbar called 'Email Markup' that
+ * includes a simplified set of WYSIWYG tools that are supported by
+ * this plugin
+ *
+ * @since 1.2.0
+ * @author Jo Dickson
+ * @param array $toolbars Array of toolbar information from ACF
+ * @return array
+ */
+function acf_email_wysiwyg_toolbar( $toolbars ) {
+	$toolbars['Email Editor'] = array();
+	$toolbars['Email Editor'][1] = email_wysiwyg_toolbar_r1();
+
+	return $toolbars;
+}
+
+add_filter( 'acf/fields/wysiwyg/toolbars', 'acf_email_wysiwyg_toolbar' );
+
+
+/**
+ * Sets available buttons in the first row of the
+ * Classic Editor's WYSIWYG toolbar.
+ *
+ * @since 1.2.0
+ * @author Jo Dickson
+ * @return array
+ */
+function mce_email_wysiwyg_toolbar_r1( $buttons ) {
+	global $post;
+	if ( $post && $post instanceof WP_Post && $post->post_type === 'ucf-email' ) {
+		$buttons = email_wysiwyg_toolbar_r1();
+	}
+
+	return $buttons;
+}
+
+add_filter( 'mce_buttons', 'mce_email_wysiwyg_toolbar_r1', 10, 1 );
+
+
+/**
+ * Sets available buttons in the second row of the
+ * Classic Editor's WYSIWYG toolbar.
+ *
+ * @since 1.2.0
+ * @author Jo Dickson
+ * @return array
+ */
+function mce_email_wysiwyg_toolbar_r2( $buttons ) {
+	global $post;
+	if ( $post && $post instanceof WP_Post && $post->post_type === 'ucf-email' ) {
+		$buttons = email_wysiwyg_toolbar_r2();
+	}
+
+	return $buttons;
+}
+
+add_filter( 'mce_buttons_2', 'mce_email_wysiwyg_toolbar_r2', 10, 1 );
+
+
+/**
+ * Sets available block format options in the
+ * Classic Editor WYSIWYG.
+ *
+ * @since 1.2.0
+ * @author Jo Dickson
+ * @return array
+ */
+function mce_before_init_insert_formats( $settings ) {
+	$settings['block_formats'] = 'Paragraph=p;Heading 2=h2';
+
+	return $settings;
+}
+
+add_filter( 'tiny_mce_before_init', 'mce_before_init_insert_formats' );

--- a/includes/admin.php
+++ b/includes/admin.php
@@ -114,3 +114,27 @@ function mce_before_init_insert_formats( $settings ) {
 }
 
 add_filter( 'tiny_mce_before_init', 'mce_before_init_insert_formats' );
+
+
+/**
+ * Removes unsupported elements from the plaintext editor's
+ * "quicktags" toolbar
+ *
+ * @since 1.2.0
+ * @author Jo Dickson
+ */
+function email_quicktags_settings( $qt_settings, $editor_id ) {
+	global $post;
+
+	if (
+		is_admin()
+		&& $post instanceof WP_Post
+		&& $post->post_type === 'ucf-email'
+	) {
+		$qt_settings['buttons'] = 'strong,em,link,img,ul,ol,li';
+	}
+
+	return $qt_settings;
+}
+
+add_filter( 'quicktags_settings', 'email_quicktags_settings', 10, 2 );

--- a/includes/admin.php
+++ b/includes/admin.php
@@ -4,7 +4,7 @@
  * Defines buttons that should be present in the first row
  * of WYSIWYG toolbars for email editing.
  *
- * @since 1.2.0
+ * @since 1.1.7
  * @author Jo Dickson
  * @return array
  */
@@ -30,7 +30,7 @@ function email_wysiwyg_toolbar_r1() {
  * Defines buttons that should be present in the second row
  * of WYSIWYG toolbars for email editing.
  *
- * @since 1.2.0
+ * @since 1.1.7
  * @author Jo Dickson
  * @return array
  */
@@ -44,7 +44,7 @@ function email_wysiwyg_toolbar_r2() {
  * includes a simplified set of WYSIWYG tools that are supported by
  * this plugin
  *
- * @since 1.2.0
+ * @since 1.1.7
  * @author Jo Dickson
  * @param array $toolbars Array of toolbar information from ACF
  * @return array
@@ -63,7 +63,7 @@ add_filter( 'acf/fields/wysiwyg/toolbars', 'acf_email_wysiwyg_toolbar' );
  * Sets available buttons in the first row of the
  * Classic Editor's WYSIWYG toolbar.
  *
- * @since 1.2.0
+ * @since 1.1.7
  * @author Jo Dickson
  * @return array
  */
@@ -83,7 +83,7 @@ add_filter( 'mce_buttons', 'mce_email_wysiwyg_toolbar_r1', 10, 1 );
  * Sets available buttons in the second row of the
  * Classic Editor's WYSIWYG toolbar.
  *
- * @since 1.2.0
+ * @since 1.1.7
  * @author Jo Dickson
  * @return array
  */
@@ -103,7 +103,7 @@ add_filter( 'mce_buttons_2', 'mce_email_wysiwyg_toolbar_r2', 10, 1 );
  * Sets available block format options in the
  * Classic Editor WYSIWYG.
  *
- * @since 1.2.0
+ * @since 1.1.7
  * @author Jo Dickson
  * @return array
  */
@@ -120,7 +120,7 @@ add_filter( 'tiny_mce_before_init', 'mce_before_init_insert_formats' );
  * Removes unsupported elements from the plaintext editor's
  * "quicktags" toolbar
  *
- * @since 1.2.0
+ * @since 1.1.7
  * @author Jo Dickson
  */
 function email_quicktags_settings( $qt_settings, $editor_id ) {

--- a/ucf-email-editor-plugin.php
+++ b/ucf-email-editor-plugin.php
@@ -12,17 +12,20 @@ if ( ! defined( 'WPINC' ) ) {
 	die;
 }
 
-define( 'UCF_EMAIL_EDITOR__PLUGIN_URL', plugins_url( basename( dirname( __FILE__ ) ) ) );
 define( 'UCF_EMAIL_EDITOR__PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
+define( 'UCF_EMAIL_EDITOR__PLUGIN_URL', plugins_url( basename( dirname( __FILE__ ) ) ) );
 define( 'UCF_EMAIL_EDITOR__PLUGIN_FILE', __FILE__ );
 define( 'UCF_EMAIL_EDITOR__STATIC_URL', plugins_url( 'static', __FILE__ ) );
 define( 'UCF_EMAIL_EDITOR__JS_URL', UCF_EMAIL_EDITOR__STATIC_URL . '/js' );
 define( 'UCF_EMAIL_EDITOR__IMG_URL', UCF_EMAIL_EDITOR__STATIC_URL . '/img' );
 
-include_once 'includes/functions.php';
-include_once 'includes/ucf-email-editor-config.php';
-include_once 'includes/ucf-email-posttype.php';
-include_once 'templates/templates.php';
+
+include_once UCF_EMAIL_EDITOR__PLUGIN_DIR . 'includes/admin.php';
+include_once UCF_EMAIL_EDITOR__PLUGIN_DIR . 'includes/functions.php';
+include_once UCF_EMAIL_EDITOR__PLUGIN_DIR . 'includes/ucf-email-editor-config.php';
+include_once UCF_EMAIL_EDITOR__PLUGIN_DIR . 'includes/ucf-email-posttype.php';
+include_once UCF_EMAIL_EDITOR__PLUGIN_DIR . 'templates/templates.php';
+
 
 if ( ! function_exists( 'ucf_email_editor_plugin_activation' ) ) {
 	function ucf_email_editor_plugin_activation() {


### PR DESCRIPTION
<!---
Thank you for contributing to UCF-Email-Editor-Plugin.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/UCF-Email-Editor-Plugin/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
<!--- Describe your changes in detail -->
- Added functions for defining what toolbar buttons should be returned for TinyMCE WYSIWYG editors throughout WordPress.  The buttons defined in these functions (`email_wysiwyg_toolbar_r1()`, `email_wysiwyg_toolbar_r2()`) reflect elements that we currently support in our email markup logic.
- Added a new ACF WYSIWYG toolbar definition, "Email Editor", that utilizes the pared-down toolbar button options. (Not currently in use, but is available in case we need it down the road)
- Updated the post content editor for emails to use the simplified TinyMCE toolbar, as well as simplified "quicktag" buttons in the plaintext editor toolbar.

Unrelated:
- Updated `include_once`s in functions.php to not use relative includes.

**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
To make the supported markup features in this plugin more obvious, and avoid use of unsupported markup in emails.

**How Has This Been Tested?**
<!--- Please describe how you tested your changes. -->
Reviewed in Dev.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
