### PR TITLE
Updated parsing options on the dom loadHTML function

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -200,7 +200,7 @@ function apply_link_utm_params( $str, $source='', $medium='', $campaign='', $con
 
 	if ( $pattern ) {
 		$dom = new DomDocument();
-		$dom->loadHTML( $str, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD );
+		$dom->loadHTML( $str );
 
 		foreach ( $dom->getElementsByTagName( 'a' ) as $elem ) {
 			$href = $elem->getAttribute( 'href' );
@@ -220,8 +220,12 @@ function apply_link_utm_params( $str, $source='', $medium='', $campaign='', $con
 
 		// Make sure `$dom->saveHTML()` doesn't return false:
 		$modified_str = $dom->saveHTML();
+
+		$start = strpos( $modified_str, '<body>' ) + 6;
+		$end = strpos( $modified_str, '</body>' ) - strlen( $modified_str );
+
 		if ( $modified_str ) {
-			$str = $modified_str;
+			$str = substr( $modified_str, $start, $end );
 		}
 	}
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -199,8 +199,9 @@ function apply_link_utm_params( $str, $source='', $medium='', $campaign='', $con
 	$pattern = UCF_Email_Editor_Config::get_option_or_default( 'utm_replace_regex' );
 
 	if ( $pattern ) {
-		$dom = new DOMDocument();
-		$dom->loadHTML( $str );
+		$dom = new DomDocument();
+		$dom->loadHTML( $str, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD );
+
 		foreach ( $dom->getElementsByTagName( 'a' ) as $elem ) {
 			$href = $elem->getAttribute( 'href' );
 			if ( preg_match( $pattern, $href ) ) {
@@ -216,6 +217,7 @@ function apply_link_utm_params( $str, $source='', $medium='', $campaign='', $con
 				);
 			}
 		}
+
 		// Make sure `$dom->saveHTML()` doesn't return false:
 		$modified_str = $dom->saveHTML();
 		if ( $modified_str ) {


### PR DESCRIPTION
<!---
Thank you for contributing to UCF-Email-Editor-Plugin.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/UCF-Email-Editor-Plugin/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
Ensures the `html` and `body` tags, along with the commented meta tag that's usually at the top of html documents is not output when parsing HTML with the DOMDocument class for UTM insertion.

**Motivation and Context**
We would like to not have html documents within our html document.

**How Has This Been Tested?**
Changes is available for review in DEV _and_ QA.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
