### PR TITLE
DomDocument character encoding bugfix

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -200,7 +200,21 @@ function apply_link_utm_params( $str, $source='', $medium='', $campaign='', $con
 
 	if ( $pattern ) {
 		$dom = new DomDocument();
-		$dom->loadHTML( $str );
+		// Dumb hack that enforces correct character encoding
+		// for DomDocument->loadHTML().
+		//
+		// This logic makes the loose assumption that an HTML
+		// string ($str) that does not begin with a DOCTYPE
+		// declaration is an incomplete HTML document, and
+		// needs an encoding declaration added to it.
+		// Should be "good enough" for our use cases:
+		if ( substr( trim( $str ), 0, strlen( '<!DOCTYPE' ) !== '<!DOCTYPE' ) ) {
+			$loaded_str = '<?xml encoding="utf-8" ?>' . $str;
+		}
+		else {
+			$loaded_str = $str;
+		}
+		$dom->loadHTML( $loaded_str );
 
 		foreach ( $dom->getElementsByTagName( 'a' ) as $elem ) {
 			$href = $elem->getAttribute( 'href' );


### PR DESCRIPTION
<!---
Thank you for contributing to UCF-Email-Editor-Plugin.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/UCF-Email-Editor-Plugin/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
<!--- Describe your changes in detail -->
Added a ~hack~fix to enforce the correct character encoding on HTML string partials passed to `DomDocument->loadHTML()` in `apply_link_utm_params()`.

**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Apparently `loadHTML()` will assume ISO-whatever encoding by default if one isn't already defined within the HTML string you pass in--and this is resulting in garbled characters on the coronavirus emails on GMUCF, which utilize this function.

**How Has This Been Tested?**
<!--- Please describe how you tested your changes. -->
Tested in Dev against Email CPT email markup and CV email markup that includes offensive curly quotes.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
